### PR TITLE
[language_activation] Try using request language rather then from the url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,16 @@ Add it to your ``INSTALLED_APPS``:
         ...
     )
 
+Add the Locale middleware (if it isn't already):
+
+.. code-block:: python
+
+    MIDDLEWARE = (
+    ...
+    'django.middleware.locale.LocaleMiddleware',
+    )
+
+
 Set your default template:
 
 .. code-block:: python

--- a/djangocms_spa/decorators.py
+++ b/djangocms_spa/decorators.py
@@ -9,15 +9,17 @@ from django.utils.decorators import available_attrs
 def cache_view(view_func):
     @wraps(view_func, assigned=available_attrs(view_func))
     def _wrapped_view_func(view, *args, **kwargs):
-        cache_key = view.request.get_full_path()
+        request = view.request
+        language_code = request.LANGUAGE_CODE
+        cache_key = '{path}:{lang}'.format(path=request.get_full_path(), lang=language_code)
         cached_response = cache.get(cache_key)
 
-        if cached_response and not view.request.user.is_authenticated():
+        if cached_response and not request.user.is_authenticated():
             return cached_response
 
         response = view_func(view, *args, **kwargs)
 
-        if response.status_code == 200 and not view.request.user.is_authenticated():
+        if response.status_code == 200 and not request.user.is_authenticated():
             try:
                 set_cache_after_rendering(cache_key, response, settings.DJANGOCMS_SPA_CACHE_TIMEOUT)
             except ContentNotRenderedError:

--- a/djangocms_spa/urls.py
+++ b/djangocms_spa/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import url
 from .views import SpaCmsPageDetailApiView
 
 urlpatterns = [
-    url(r'^(?P<language_code>[\w-]+)/pages/$', SpaCmsPageDetailApiView.as_view(), name='cms_page_detail_home'),
-    url(r'^(?P<language_code>[\w-]+)/pages/(?P<path>.*)/$', SpaCmsPageDetailApiView.as_view(), name='cms_page_detail'),
+    url(r'^pages/$', SpaCmsPageDetailApiView.as_view(), name='cms_page_detail_home'),
+    url(r'^pages/(?P<path>.*)/$', SpaCmsPageDetailApiView.as_view(), name='cms_page_detail'),
 ]

--- a/djangocms_spa/views.py
+++ b/djangocms_spa/views.py
@@ -80,9 +80,12 @@ class SingleObjectSpaMixin(MetaDataMixin, ObjectPermissionMixin, SingleObjectMix
         return data
 
 
-@method_decorator(cache_view, name='dispatch')
 class SpaApiView(APIView):
     template_name = None
+
+    @cache_view
+    def dispatch(self, request, *args, **kwargs):
+        return super(SpaApiView, self).dispatch(request, *args, **kwargs)
 
     def get(self, *args, **kwargs):
         data = {

--- a/djangocms_spa/views.py
+++ b/djangocms_spa/views.py
@@ -3,6 +3,7 @@ import json
 from cms.utils.page_resolver import get_page_from_request
 from django.conf import settings
 from django.http import HttpResponse, JsonResponse
+from django.utils.decorators import method_decorator
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.list import MultipleObjectMixin
 from rest_framework.views import APIView
@@ -79,15 +80,10 @@ class SingleObjectSpaMixin(MetaDataMixin, ObjectPermissionMixin, SingleObjectMix
         return data
 
 
+@method_decorator(cache_view, name='dispatch')
 class SpaApiView(APIView):
     template_name = None
 
-    @cache_view
-    def dispatch(self, request, **kwargs):
-        # Take the language from the URL kwarg and set it as request language
-        return super(SpaApiView, self).dispatch(request, **kwargs)
-    
-    
     def get(self, *args, **kwargs):
         data = {
             'data': self.get_fetched_data()

--- a/djangocms_spa/views.py
+++ b/djangocms_spa/views.py
@@ -85,16 +85,8 @@ class SpaApiView(APIView):
     @cache_view
     def dispatch(self, request, **kwargs):
         # Take the language from the URL kwarg and set it as request language
-        self.set_language(kwargs, request)
         return super(SpaApiView, self).dispatch(request, **kwargs)
     
-    def set_language(self, kwargs, request):
-        if hasattr(request, "LANGUAGE_CODE"):
-            language_code = request.LANGUAGE_CODE
-        else:
-            language_code = kwargs.pop('language_code')
-        available_languages = {language[0] for language in settings.LANGUAGES}
-        request.LANGUAGE_CODE = language_code if language_code in available_languages else settings.LANGUAGES[0][0]
     
     def get(self, *args, **kwargs):
         data = {

--- a/djangocms_spa/views.py
+++ b/djangocms_spa/views.py
@@ -85,11 +85,17 @@ class SpaApiView(APIView):
     @cache_view
     def dispatch(self, request, **kwargs):
         # Take the language from the URL kwarg and set it as request language
-        language_code = kwargs.pop('language_code')
-        available_languages = [language[0] for language in settings.LANGUAGES]
-        request.LANGUAGE_CODE = language_code if language_code in available_languages else settings.LANGUAGES[0][0]
+        self.set_language(kwargs, request)
         return super(SpaApiView, self).dispatch(request, **kwargs)
-
+    
+    def set_language(self, kwargs, request):
+        if hasattr(request, "LANGUAGE_CODE"):
+            language_code = request.LANGUAGE_CODE
+        else:
+            language_code = kwargs.pop('language_code')
+        available_languages = {language[0] for language in settings.LANGUAGES}
+        request.LANGUAGE_CODE = language_code if language_code in available_languages else settings.LANGUAGES[0][0]
+    
     def get(self, *args, **kwargs):
         data = {
             'data': self.get_fetched_data()


### PR DESCRIPTION
1. Is that handling even necessary? Can't we just use django's language handling?
2. Should it be the other way around? First get the language from the kwargs and use the requests language as a fallback?