### PR TITLE
Add dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,5 +76,6 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,11 @@ setup(
         'djangocms_spa',
     ],
     include_package_data=True,
-    install_requires=[],
+    install_requires=[
+        "django-cms>=3.0",
+        "djangorestframework>=3.5.0",
+        "django-appconf>=1.0.1",
+    ],
     license="MIT",
     zip_safe=False,
     keywords='djangocms-spa',


### PR DESCRIPTION
Because the `SpaAPIView` inherits from the restframeworks `APIView` the django server does not start without installing it by hand. To skip this manual step, the dependencies were added to setup.py.